### PR TITLE
Updated ImageCache utility

### DIFF
--- a/AnimalFacts/AnimalFacts.xcodeproj/project.pbxproj
+++ b/AnimalFacts/AnimalFacts.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		52A2803F29521A44002883DE /* Injected.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A2803E29521A44002883DE /* Injected.swift */; };
+		52A2804129521A7E002883DE /* InjectionKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A2804029521A7E002883DE /* InjectionKeys.swift */; };
 		BE160A0928DF84E00031287F /* View+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE160A0828DF84E00031287F /* View+Extension.swift */; };
 		BE3E57D128DC570500C7048C /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BE3E57D028DC570500C7048C /* Preview Assets.xcassets */; };
 		BE3E57DB28DC579A00C7048C /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE3E57DA28DC579A00C7048C /* AppState.swift */; };
@@ -99,6 +101,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		52A2803E29521A44002883DE /* Injected.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Injected.swift; sourceTree = "<group>"; };
+		52A2804029521A7E002883DE /* InjectionKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectionKeys.swift; sourceTree = "<group>"; };
 		BE160A0828DF84E00031287F /* View+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extension.swift"; sourceTree = "<group>"; };
 		BE3E57D028DC570500C7048C /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		BE3E57DA28DC579A00C7048C /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
@@ -356,6 +360,8 @@
 			isa = PBXGroup;
 			children = (
 				BE3E57FF28DC65FB00C7048C /* Sorted.swift */,
+				52A2803E29521A44002883DE /* Injected.swift */,
+				52A2804029521A7E002883DE /* InjectionKeys.swift */,
 			);
 			path = PropertyWrappers;
 			sourceTree = "<group>";
@@ -734,6 +740,7 @@
 			files = (
 				BE3E585128DCD46800C7048C /* HapticGenerator.swift in Sources */,
 				BE3E57E128DC57D000C7048C /* StoreProvider.swift in Sources */,
+				52A2803F29521A44002883DE /* Injected.swift in Sources */,
 				BE3E580F28DC66F200C7048C /* CategoriesConnector.swift in Sources */,
 				BE3E57EF28DC588A00C7048C /* Action.swift in Sources */,
 				BE3E583B28DCB91900C7048C /* FactsConnector.swift in Sources */,
@@ -776,6 +783,7 @@
 				BE3E585428DCD4D500C7048C /* GraphFacts.swift in Sources */,
 				BE3E581428DC673700C7048C /* CategoryView.swift in Sources */,
 				BEF28AA228DF40CC006B5C9D /* StorageCategoryModel.swift in Sources */,
+				52A2804129521A7E002883DE /* InjectionKeys.swift in Sources */,
 				BEF28A9D28DF3EBC006B5C9D /* StorageDriver.swift in Sources */,
 				BE3E588028DE061A00C7048C /* CardStackModel.swift in Sources */,
 				BE3E585928DCD51F00C7048C /* FactsReducer.swift in Sources */,

--- a/AnimalFacts/AnimalFacts/Source/Core/Operators/Network/Targets/ImagesTarget.swift
+++ b/AnimalFacts/AnimalFacts/Source/Core/Operators/Network/Targets/ImagesTarget.swift
@@ -12,7 +12,7 @@ import UIKit
 struct ImagesTarget: NetworkTarget {
   typealias Operation = NetworkOperator.Operation
 
-  @Environment(\.imageCache) var imageCache
+  @Injected(\.imageCache) var imageCache
 
   func map(state: AppState, client: Client, dispatch: @escaping ReduxDispatch) -> [Operation] {
     var operations: [Operation] = .empty

--- a/AnimalFacts/AnimalFacts/Source/Core/PropertyWrappers/Injected.swift
+++ b/AnimalFacts/AnimalFacts/Source/Core/PropertyWrappers/Injected.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public protocol InjectionKey {
+  /// The associated type representing the type of the dependency injection key's value.
+  associatedtype Value
+
+  /// The default value for the dependency injection key.
+  static var currentValue: Self.Value { get set }
+}
+
+/// Provides access to injected dependencies.
+struct InjectedValues {
+  /// This is only used as an accessor to the computed properties within extensions of `InjectedValues`.
+  private static var current = InjectedValues()
+
+  /// A static subscript for updating the `currentValue` of `InjectionKey` instances.
+  static subscript<K>(key: K.Type) -> K.Value where K: InjectionKey {
+    get { key.currentValue }
+    set { key.currentValue = newValue }
+  }
+
+  /// A static subscript accessor for updating and references dependencies directly.
+  static subscript<T>(_ keyPath: WritableKeyPath<InjectedValues, T>) -> T {
+    get { current[keyPath: keyPath] }
+    set { current[keyPath: keyPath] = newValue }
+  }
+}
+
+@propertyWrapper
+struct Injected<T> {
+  private let keyPath: WritableKeyPath<InjectedValues, T>
+
+  var wrappedValue: T {
+    get { InjectedValues[keyPath] }
+    set { InjectedValues[keyPath] = newValue }
+  }
+
+  init(_ keyPath: WritableKeyPath<InjectedValues, T>) {
+    self.keyPath = keyPath
+  }
+}

--- a/AnimalFacts/AnimalFacts/Source/Core/PropertyWrappers/InjectionKeys.swift
+++ b/AnimalFacts/AnimalFacts/Source/Core/PropertyWrappers/InjectionKeys.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+// MARK: - ImageCacheKey
+
+private struct ImageCacheKey: InjectionKey {
+  static var currentValue: ImageCacheProtocol = ImageCache()
+}
+
+extension InjectedValues {
+  var imageCache: ImageCacheProtocol {
+    get { Self[ImageCacheKey.self] }
+    set { Self[ImageCacheKey.self] = newValue }
+  }
+}

--- a/AnimalFacts/AnimalFacts/Source/Scenes/Categories/Graph/GraphCategories.swift
+++ b/AnimalFacts/AnimalFacts/Source/Scenes/Categories/Graph/GraphCategories.swift
@@ -33,7 +33,7 @@ struct GraphCategories {
 }
 
 struct GraphCategory {
-  @Environment(\.imageCache) var imageCache
+  @Injected(\.imageCache) var imageCache
 
   let graph: Graph
   let id: CategoryModel.ID

--- a/AnimalFacts/AnimalFacts/Source/Scenes/Categories/View/Row/CategoryConnector.swift
+++ b/AnimalFacts/AnimalFacts/Source/Scenes/Categories/View/Row/CategoryConnector.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct CategoryConnector: Connector {
-  @Environment(\.imageCache) var imageCache
+  @Injected(\.imageCache) var imageCache
 
   let id: CategoryModel.ID
 

--- a/AnimalFacts/AnimalFacts/Source/Scenes/Facts/View/Row/FactConnector.swift
+++ b/AnimalFacts/AnimalFacts/Source/Scenes/Facts/View/Row/FactConnector.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct FactConnector: Connector {
-  @Environment(\.imageCache) var imageCache
+  @Injected(\.imageCache) var imageCache
 
   let id: FactModel.ID
   let previousAction: Command<Void>?

--- a/AnimalFacts/AnimalFacts/Source/Utility/ImageCache.swift
+++ b/AnimalFacts/AnimalFacts/Source/Utility/ImageCache.swift
@@ -8,18 +8,18 @@
 import Combine
 import SwiftUI
 
-struct ImageCacheKey: EnvironmentKey {
-  static let defaultValue = ImageCache()
+enum ImageCacheTypeID {
+  case category(CategoryModel.ID)
+  case fact(FactModel.ID)
 }
 
-extension EnvironmentValues {
-  var imageCache: ImageCache {
-    get { self[ImageCacheKey.self] }
-    set { self[ImageCacheKey.self] = newValue }
-  }
+protocol ImageCacheProtocol {
+  func store(_ image: UIImage, for id: ImageCacheTypeID)
+  func image(for id: ImageCacheTypeID) -> UIImage
 }
 
-class ImageCache {
+class ImageCache: ImageCacheProtocol {
+  typealias ID = ImageCacheTypeID
   private var categories: [CategoryModel.ID: UIImage] = .empty
   private var facts: [FactModel.ID: UIImage] = .empty
 
@@ -39,12 +39,5 @@ class ImageCache {
     case let .fact(factId):
       return facts[factId] ?? UIImage(named: "pets")!
     }
-  }
-}
-
-extension ImageCache {
-  enum ID {
-    case category(CategoryModel.ID)
-    case fact(FactModel.ID)
   }
 }


### PR DESCRIPTION
Improved ImageCache to avoid accessing environment warnings.

There was a warning "Accessing Environment<ImageCache>'s value outside of being installed on a View. This will always read the default value and will not update." I have changed property wrapper `@Environment` to custom `@Injected` to avoid warnings. More details about injected described here: https://www.avanderlee.com/swift/dependency-injection/